### PR TITLE
Global changes

### DIFF
--- a/Editor/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Stats/ExtraData/Data.stats
+++ b/Editor/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Stats/ExtraData/Data.stats
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="utf-8"?>
+<stats stat_object_definition_id="43178832-7920-4a69-8b7e-bcebc518c388">
+  <stat_objects>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="VitalityStartingAmount" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="80" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="VitalityExponentialGrowth" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="1.1" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="VitalityLinearGrowth" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="20" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="FirstVitalityLeapLevel" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="50" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="FirstVitalityLeapGrowth" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="1" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SecondVitalityLeapLevel" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="50" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SecondVitalityLeapGrowth" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="1" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ThirdVitalityLeapLevel" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="50" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ThirdVitalityLeapGrowth" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="1" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="FourthVitalityLeapLevel" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="50" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="FourthVitalityLeapGrowth" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="1" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="DamageBoostFromAttribute" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="DodgingBoostFromAttribute" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0.01" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ArmorToVitalityRatio" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0.3" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ArmorRingPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ArmorAmuletPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ArmorBeltPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ArmorFeetPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0.15" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ArmorHandsPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0.15" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ArmorShieldPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0.5" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ArmorLowerBodyPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0.2" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ArmorHeadPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0.15" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="ArmorUpperBodyPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0.3" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="CombatAbilityCap" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="6" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="CombatAbilityLevelGrowth" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="CombatAbilityDamageBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="CombatAbilityCritMultiplierBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="CombatAbilityReflectionBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="CombatAbilityDodgingBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="CombatAbilityAccuracyBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="CombatAbilityCritBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="LeadershipRange" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="LeadershipAllResBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="LeadershipDodgingBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="InitiativeBonusFromWits" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="WeaponAccuracyPenaltyPerLevel" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="-5" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="WeaponAccuracyPenaltyCap" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="-20" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="HighGroundBaseDamageBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="HighGroundThreshold" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="4" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="HighGroundRangeMultiplier" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="1.5" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="LowGroundBaseDamagePenalty" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SneakDefaultAPCost" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="1" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SneakSpeedBoost" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilitySulfuricDamageBoostPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityPhysicalDamageBoostPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityWaterDamageBoostPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityFireDamageBoostPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityAirDamageBoostPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityPoisonAndEarthDamageBoostPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityVitalityRestoredPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="5" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityHighGroundBonusPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityArmorRestoredPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="5" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityLifeStealPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="10" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityCritMultiplierPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SkillAbilityMovementSpeedPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="SummoningAbilityBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="15" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="AbilityPerseveranceArmorPerPoint" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="0" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="IncarnateSummoningLevel" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="6" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="LoneWolfArmorBoostPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="60" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="LoneWolfMagicArmorBoostPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="60" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="LoneWolfAPBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="2" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="LoneWolfVitalityBoostPercentage" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="30" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="LoneWolfMaxAPBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="2" />
+      </fields>
+    </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="TalentQuickStepPartialApBonus" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="1" />
+      </fields>
+    </stat_object>
+  </stat_objects>
+</stats>

--- a/Editor/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Stats/Stats/Potion.stats
+++ b/Editor/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Stats/Stats/Potion.stats
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<stats stat_object_definition_id="48e63fff-81e0-42bb-ac51-39f5904b97be">
+  <stat_objects>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="Stats_Summoning_Ability" />
+        <field name="Act" type="EnumerationStatObjectFieldDefinition" value="0" enumeration_type_name="Act" />
+        <field name="Act part" type="EnumerationStatObjectFieldDefinition" value="0" enumeration_type_name="ActPart" />
+        <field name="VitalityBoost" type="IntegerStatObjectFieldDefinition" value="15" />
+        <field name="DamageBoost" type="IntegerStatObjectFieldDefinition" value="15" />
+        <field name="MagicArmorBoost" type="IntegerStatObjectFieldDefinition" value="15" />
+      </fields>
+    </stat_object>
+  </stat_objects>
+</stats>

--- a/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Goals/WotL_LevelUp.txt
+++ b/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Goals/WotL_LevelUp.txt
@@ -1,0 +1,17 @@
+Version 1
+SubGoalCombiner SGC_AND
+INITSECTION
+
+KBSECTION
+IF
+	CharacterLeveledUp(_Char)
+AND
+	CharacterGetLevel(_Char, _Level)
+AND
+	NOT QRY_WotL_IntegerIsDivisible(_Level, 2)
+THEN
+	CharacterAddAbilityPoint(_Char, 1);
+EXITSECTION
+
+ENDEXITSECTION
+ParentTargetEdge "__WotL_Goal"

--- a/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Goals/WotL_LevelUp.txt
+++ b/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Goals/WotL_LevelUp.txt
@@ -3,6 +3,7 @@ SubGoalCombiner SGC_AND
 INITSECTION
 
 KBSECTION
+//REGION Adds ability point at odd levels
 IF
 	CharacterLeveledUp(_Char)
 AND
@@ -11,6 +12,7 @@ AND
 	NOT QRY_WotL_IntegerIsDivisible(_Level, 2)
 THEN
 	CharacterAddAbilityPoint(_Char, 1);
+//END_REGION
 EXITSECTION
 
 ENDEXITSECTION

--- a/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Goals/WotL_Utils.txt
+++ b/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Goals/WotL_Utils.txt
@@ -3,6 +3,7 @@ SubGoalCombiner SGC_AND
 INITSECTION
 
 KBSECTION
+//REGION Integer Is Divisible
 QRY
 	QRY_WotL_IntegerIsDivisible((INTEGER)_A, (INTEGER)_B)
 AND
@@ -11,6 +12,7 @@ AND
 	IntegerProduct(_B, _Q, _A)
 THEN
 	DB_NOOP(1);
+//END_REGION
 EXITSECTION
 
 ENDEXITSECTION

--- a/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Goals/WotL_Utils.txt
+++ b/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Goals/WotL_Utils.txt
@@ -1,0 +1,17 @@
+Version 1
+SubGoalCombiner SGC_AND
+INITSECTION
+
+KBSECTION
+QRY
+	QRY_WotL_IntegerIsDivisible((INTEGER)_A, (INTEGER)_B)
+AND
+	IntegerDivide(_A, _B, _Q)
+AND
+	IntegerProduct(_B, _Q, _A)
+THEN
+	DB_NOOP(1);
+EXITSECTION
+
+ENDEXITSECTION
+ParentTargetEdge "__WotL_Goal"

--- a/Public/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Stats/Generated/Data/Data.txt
+++ b/Public/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Stats/Generated/Data/Data.txt
@@ -1,0 +1,128 @@
+key "VitalityStartingAmount","80"
+
+key "VitalityExponentialGrowth","1.1"
+
+key "VitalityLinearGrowth","20"
+
+key "FirstVitalityLeapLevel","50"
+
+key "FirstVitalityLeapGrowth","1"
+
+key "SecondVitalityLeapLevel","50"
+
+key "SecondVitalityLeapGrowth","1"
+
+key "ThirdVitalityLeapLevel","50"
+
+key "ThirdVitalityLeapGrowth","1"
+
+key "FourthVitalityLeapLevel","50"
+
+key "FourthVitalityLeapGrowth","1"
+
+key "DamageBoostFromAttribute","0"
+
+key "DodgingBoostFromAttribute","0.01"
+
+key "ArmorToVitalityRatio","0.3"
+
+key "ArmorRingPercentage","0"
+
+key "ArmorAmuletPercentage","0"
+
+key "ArmorBeltPercentage","0"
+
+key "ArmorFeetPercentage","0.15"
+
+key "ArmorHandsPercentage","0.15"
+
+key "ArmorShieldPercentage","0.5"
+
+key "ArmorLowerBodyPercentage","0.2"
+
+key "ArmorHeadPercentage","0.15"
+
+key "ArmorUpperBodyPercentage","0.3"
+
+key "CombatAbilityCap","6"
+
+key "CombatAbilityLevelGrowth","0"
+
+key "CombatAbilityDamageBonus","0"
+
+key "CombatAbilityCritMultiplierBonus","0"
+
+key "CombatAbilityReflectionBonus","0"
+
+key "CombatAbilityDodgingBonus","0"
+
+key "CombatAbilityAccuracyBonus","0"
+
+key "CombatAbilityCritBonus","0"
+
+key "LeadershipRange","0"
+
+key "LeadershipAllResBonus","0"
+
+key "LeadershipDodgingBonus","0"
+
+key "InitiativeBonusFromWits","0"
+
+key "WeaponAccuracyPenaltyPerLevel","-5"
+
+key "WeaponAccuracyPenaltyCap","-20"
+
+key "HighGroundBaseDamageBonus","0"
+
+key "HighGroundThreshold","4"
+
+key "HighGroundRangeMultiplier","1.5"
+
+key "LowGroundBaseDamagePenalty","0"
+
+key "SneakDefaultAPCost","1"
+
+key "SneakSpeedBoost","0"
+
+key "SkillAbilitySulfuricDamageBoostPerPoint","0"
+
+key "SkillAbilityPhysicalDamageBoostPerPoint","0"
+
+key "SkillAbilityWaterDamageBoostPerPoint","0"
+
+key "SkillAbilityFireDamageBoostPerPoint","0"
+
+key "SkillAbilityAirDamageBoostPerPoint","0"
+
+key "SkillAbilityPoisonAndEarthDamageBoostPerPoint","0"
+
+key "SkillAbilityVitalityRestoredPerPoint","5"
+
+key "SkillAbilityHighGroundBonusPerPoint","0"
+
+key "SkillAbilityArmorRestoredPerPoint","5"
+
+key "SkillAbilityLifeStealPerPoint","10"
+
+key "SkillAbilityCritMultiplierPerPoint","0"
+
+key "SkillAbilityMovementSpeedPerPoint","0"
+
+key "SummoningAbilityBonus","15"
+
+key "AbilityPerseveranceArmorPerPoint","0"
+
+key "IncarnateSummoningLevel","6"
+
+key "LoneWolfArmorBoostPercentage","60"
+
+key "LoneWolfMagicArmorBoostPercentage","60"
+
+key "LoneWolfAPBonus","2"
+
+key "LoneWolfVitalityBoostPercentage","30"
+
+key "LoneWolfMaxAPBonus","2"
+
+key "TalentQuickStepPartialApBonus","1"
+

--- a/Public/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Stats/Generated/Data/Potion.txt
+++ b/Public/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Stats/Generated/Data/Potion.txt
@@ -1,0 +1,8 @@
+new entry "Stats_Summoning_Ability"
+type "Potion"
+data "Act" "1"
+data "Act part" "0"
+data "VitalityBoost" "15"
+data "DamageBoost" "15"
+data "MagicArmorBoost" "15"
+


### PR DESCRIPTION
Global changes to ExtraData
* HP is set to 100 at lvl 1, increase at 20/lvl with a 1.1 exponential rate, so it gradually increases to 30/lvl, then 35/lvl, etc. It ends up at about 60/lvl on high levels.
* Finesse adds 1% dodge per point.
* `ArmorToVitalityRatio` can be adjusted to adjust the Armor impact in the character's effective health.
* Accessories don't give armor.
* The armor percentages can be adjusted at will.
* Combat Ability Cap at 6.
* Combat Ability is with Story code (1 each 2 lvls).
* Weapon Abilities don't grant anything and will be used as skill memorization requirement.
* Defensive Abilities don't grant anything yet.
* Reduced the penalty for using higher level weapons to -5% accuracy per level diff, up to 20%.
* High Ground provides range bonus only, decreased from 2.5 to 1.5. Also increased the height diff threshold for activation from 2.4 to 4m. Low Ground don't give damage penalty.
* Decreased Sneak AP Cost to 1 and removed the MS penalty.
* Skill Abilities no longer grant passive bonuses, except:
   * Hydrosophist (gives 5% more healing and armor regen);
   * Geomancer (gives 5% more armor regen, but won't be used for anything);
   * Necromancer (10% Lifesteal);
   * Summoning (15% bonus stats);
* Decreased the incarnate level transformation to 6 Summoning
* Lone Wolf stats are included for tweaking when necessary.
* The Pawn `TalentQuickStepPartialApBonus` can be tweaked as well.
* Modifies the summoning Potion entry to match the tooltip.
* Adds the story code to give the combat ability point every two levels.