### PR TITLE
Backstab lua code

### DIFF
--- a/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Goals/WotL_Backstab.txt
+++ b/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Goals/WotL_Backstab.txt
@@ -3,25 +3,20 @@ SubGoalCombiner SGC_AND
 INITSECTION
 
 KBSECTION
-/*
 //REGION Backstab handler
 // Transforms the insta-crit into a normal crit random roll, while providing
 // a damage boost instead.
 IF
-	NRD_OnPrepareHit(_, _, _, _Handle)
+	NRD_OnHit(_Target, _Source, _, _Handle)
 AND
-	NRD_HitGetInt(_Handle, "AlwaysBackstab", _Value)
+	NRD_StatusGetInt(_Target, _Handle, "Hit", 1)
+AND
+	NRD_StatusGetInt(_Target, _Handle, "AlwaysBackstab", 1)
 THEN
-	NRD_DebugLog((STRING)_Value);
+	NRD_LuaCall("WotL_Backstab", (STRING)_Target, (STRING)_Source, (STRING)_Handle);
 //END_REGION
 
-IF
-	NRD_OnHit(_Char, _, _, _Handle)
-AND
-	NRD_StatusGetInt(_Char, _Handle, "AlwaysBackstab", 1)
-THEN
-	NRD_HitClearAllDamage(_Handle);
-*/
+
 EXITSECTION
 
 ENDEXITSECTION

--- a/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Lua/Bootstrap.lua
+++ b/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Lua/Bootstrap.lua
@@ -1,6 +1,7 @@
 Ext.Require("Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66","WotL_Abilities.lua")
 Ext.Require("Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66","WotL_ArmorSpeciality.lua")
 Ext.Require("Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66","WotL_Attributes.lua")
+Ext.Require("Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66","WotL_Backstab.lua")
 Ext.Require("Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66","WotL_CustomHitChance.lua")
 Ext.Require("Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66","WotL_MagicArtifacts.lua")
 Ext.Require("Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66","WotL_PhysicalDamage.lua")

--- a/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Lua/WotL_Backstab.lua
+++ b/Mods/Wizards_of_the_Larian_fa38d91e-49ef-4fd5-962d-db2c6ffcba66/Story/RawFiles/Lua/WotL_Backstab.lua
@@ -1,0 +1,47 @@
+ENUM_WotL_AllDamageTypes = {
+    "Air",
+    "Chaos",
+    "Corrosive",
+    "Earth",
+    "Fire",
+    "Magic",
+    "Physical",
+    "Piercing",
+    "Poison",
+    "Shadow",
+    "Water",
+}
+
+WotL_BackstabMultiplier = 1.5
+
+function WotL_Backstab(target, source, handle)
+    local weapon = CharacterGetEquippedItem(source, "Weapon")
+    local criticalDamage = NRD_ItemGetPermanentBoostInt(weapon, "CriticalDamage")
+    if criticalDamage == 0 then
+        local weaponStatsID = NRD_ItemGetStatsId(weapon)
+        criticalDamage = NRD_StatGetInt(weaponStatsID, "CriticalDamage")
+    end
+    NRD_DebugLog("Critical Damage: " .. tostring(criticalDamage))
+
+    local criticalChance = NRD_CharacterGetComputedStat(source, "CriticalChance", 0)
+    local isCritical = false
+    if criticalChance >= math.random(100) then
+        isCritical = true
+    end
+
+    for key, type in pairs(ENUM_WotL_AllDamageTypes) do
+        local damage = NRD_HitStatusGetDamage(target, handle, type)
+        if damage ~= 0 then
+            NRD_DebugLog("Damage Type: " .. type)
+            NRD_DebugLog("Damage: " .. tostring(damage))
+            local finalDamage = damage * WotL_BackstabMultiplier
+            if isCritical ~= true then
+                finalDamage = finalDamage * 100 / criticalDamage
+            end
+            NRD_DebugLog("Final Damage: " .. tostring(finalDamage))
+            local delta = finalDamage - damage
+            NRD_DebugLog("Delta: " .. tostring(delta))
+            NRD_HitStatusAddDamage(target, handle, type, delta)
+        end
+    end
+end


### PR DESCRIPTION
Implements the code for backstab, making it a static 50% increased damage, while adding the chance of Critically Strike, for the weapon's Critical Damage bonus

Change the global `WotL_BackstabMultiplier` to alter the static damage increase from backstab